### PR TITLE
made world control not crash when ic2 classic is installed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,10 @@ repositories {
 
 
 minecraft {
-	version = "1.12.2-14.23.1.2607"
+	version = "1.12.2-14.23.5.2778"
 	runDir = "run"
 
-	mappings = "snapshot_20170919"
+	mappings = "snapshot_20171003"
 
 	replace "@VERSION@", project.version
 
@@ -58,11 +58,12 @@ minecraft {
 dependencies {
 	deobfCompile "MCMultiPart2:MCMultiPart:2.3.0"
 	//deobfCompile "mcp.mobius.waila:Hwyla:1.8.20-B35_1.12"
-	deobfProvided "mezz.jei:jei_1.12.2:4.7.11.102:api"
-	runtime "mezz.jei:jei_1.12.2:4.7.11.102"
+	deobfProvided "mezz.jei:jei_${mc_version}:4.7.11.102:api"
+	runtime "mezz.jei:jei_${mc_version}:4.7.11.102"
 	//compile "net.darkhax.tesla:Tesla-1.12:1.0.61"
-	compile "net.darkhax.tesla:Tesla-1.12.2:1.0.63"
-	deobfCompile 'net.industrial-craft:industrialcraft-2:2.8.85-ex112:dev'
+	compile "net.darkhax.tesla:Tesla-${mc_version}:1.0.63"
+	deobfProvided 'net.industrial-craft:industrialcraft-2:2.8.85-ex112:api'
+	runtime 'net.industrial-craft:industrialcraft-2:2.8.85-ex112:dev'
 }
 processResources {
 	inputs.property "version", project.version

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ minecraft {
 	version = "1.12.2-14.23.1.2607"
 	runDir = "run"
 
-	mappings = "snapshot_20171003"
+	mappings = "snapshot_20170919"
 
 	replace "@VERSION@", project.version
 

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ repositories {
 
 
 minecraft {
-	version = "1.12.2-14.23.5.2778"
+	version = "1.12.2-14.23.1.2607"
 	runDir = "run"
 
 	mappings = "snapshot_20171003"
@@ -58,10 +58,10 @@ minecraft {
 dependencies {
 	deobfCompile "MCMultiPart2:MCMultiPart:2.3.0"
 	//deobfCompile "mcp.mobius.waila:Hwyla:1.8.20-B35_1.12"
-	deobfProvided "mezz.jei:jei_${mc_version}:4.7.11.102:api"
-	runtime "mezz.jei:jei_${mc_version}:4.7.11.102"
+	deobfProvided "mezz.jei:jei_1.12.2:4.7.11.102:api"
+	runtime "mezz.jei:jei_1.12.2:4.7.11.102"
 	//compile "net.darkhax.tesla:Tesla-1.12:1.0.61"
-	compile "net.darkhax.tesla:Tesla-${mc_version}:1.0.63"
+	compile "net.darkhax.tesla:Tesla-1.12.2:1.0.63"
 	deobfProvided 'net.industrial-craft:industrialcraft-2:2.8.85-ex112:api'
 	runtime 'net.industrial-craft:industrialcraft-2:2.8.85-ex112:dev'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
-forgeVersion=14.23.5.2778
-mc_version=1.12.2
+forgeVersion=1.9.4-12.17.0.1939
 mappingsVersion=snapshot_20160518
 jeiVersion=3.4.3.207
 org.gradle.jvmargs=-Xmx2G

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-forgeVersion=1.9.4-12.17.0.1939
+forgeVersion=14.23.5.2778
+mc_version=1.12.2
 mappingsVersion=snapshot_20160518
 jeiVersion=3.4.3.207
 org.gradle.jvmargs=-Xmx2G

--- a/src/main/java/worldcontrolteam/worldcontrol/crossmod/industrialcraft2/ReactorUtils.java
+++ b/src/main/java/worldcontrolteam/worldcontrol/crossmod/industrialcraft2/ReactorUtils.java
@@ -16,14 +16,7 @@ public class ReactorUtils {
         if (world == null)
             return null;
         TileEntity tile = WCUtility.getTileEntity(world, pos).orElse(null);
-        if (tile == null){
-            return null;
-        } else if (tile instanceof IReactor) {
-            return (IReactor) tile;
-        }else {
-            return tile instanceof IReactorChamber ? ((IReactorChamber) tile).getReactorInstance() : null;
-        }
-
+        return tile == null ? null : tile instanceof IReactor ? (IReactor) tile : tile instanceof IReactorChamber ? ((IReactorChamber) tile).getReactorInstance() : null;
     }
 
     public static boolean isProducing(World world, BlockPos pos) {
@@ -31,14 +24,7 @@ public class ReactorUtils {
     }
 
     public static int getNuclearCellTimeLeft(ItemStack rStack) {
-        if (rStack.isEmpty()){
-            return 0;
-        } else if (rStack.getItem() instanceof IReactorComponent){
-            return rStack.getItem() instanceof ICustomDamageItem ? ((ICustomDamageItem) rStack.getItem()).getMaxCustomDamage(rStack) - ((ICustomDamageItem) rStack.getItem()).getCustomDamage(rStack) : rStack.getMaxDamage() - rStack.getItemDamage();
-        } else{
-            return 0;
-        }
-
+        return rStack.isEmpty() ? 0 : rStack.getItem() instanceof IReactorComponent ? rStack.getItem() instanceof ICustomDamageItem ? ((ICustomDamageItem) rStack.getItem()).getMaxCustomDamage(rStack) - ((ICustomDamageItem) rStack.getItem()).getCustomDamage(rStack) : rStack.getMaxDamage() - rStack.getItemDamage() : 0;
     }
 
 }

--- a/src/main/java/worldcontrolteam/worldcontrol/crossmod/industrialcraft2/ReactorUtils.java
+++ b/src/main/java/worldcontrolteam/worldcontrol/crossmod/industrialcraft2/ReactorUtils.java
@@ -3,7 +3,7 @@ package worldcontrolteam.worldcontrol.crossmod.industrialcraft2;
 import ic2.api.item.ICustomDamageItem;
 import ic2.api.reactor.IReactor;
 import ic2.api.reactor.IReactorChamber;
-import ic2.core.item.reactor.AbstractDamageableReactorComponent;
+import ic2.api.reactor.IReactorComponent;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
@@ -16,7 +16,14 @@ public class ReactorUtils {
         if (world == null)
             return null;
         TileEntity tile = WCUtility.getTileEntity(world, pos).orElse(null);
-        return tile == null ? null : tile instanceof IReactor ? (IReactor) tile : tile instanceof IReactorChamber ? ((IReactorChamber) tile).getReactorInstance() : null;
+        if (tile == null){
+            return null;
+        } else if (tile instanceof IReactor) {
+            return (IReactor) tile;
+        }else {
+            return tile instanceof IReactorChamber ? ((IReactorChamber) tile).getReactorInstance() : null;
+        }
+
     }
 
     public static boolean isProducing(World world, BlockPos pos) {
@@ -24,7 +31,14 @@ public class ReactorUtils {
     }
 
     public static int getNuclearCellTimeLeft(ItemStack rStack) {
-        return rStack.isEmpty() ? 0 : rStack.getItem() instanceof AbstractDamageableReactorComponent ? rStack.getItem() instanceof ICustomDamageItem ? ((ICustomDamageItem) rStack.getItem()).getMaxCustomDamage(rStack) - ((ICustomDamageItem) rStack.getItem()).getCustomDamage(rStack) : rStack.getMaxDamage() - rStack.getItemDamage() : 0;
+        if (rStack.isEmpty()){
+            return 0;
+        } else if (rStack.getItem() instanceof IReactorComponent){
+            return rStack.getItem() instanceof ICustomDamageItem ? ((ICustomDamageItem) rStack.getItem()).getMaxCustomDamage(rStack) - ((ICustomDamageItem) rStack.getItem()).getCustomDamage(rStack) : rStack.getMaxDamage() - rStack.getItemDamage();
+        } else{
+            return 0;
+        }
+
     }
 
 }

--- a/src/main/java/worldcontrolteam/worldcontrol/crossmod/industrialcraft2/items/IC2EnergyStorageCard.java
+++ b/src/main/java/worldcontrolteam/worldcontrol/crossmod/industrialcraft2/items/IC2EnergyStorageCard.java
@@ -1,6 +1,6 @@
 package worldcontrolteam.worldcontrol.crossmod.industrialcraft2.items;
 
-import ic2.core.block.wiring.TileEntityElectricBlock;
+import ic2.api.tile.IEnergyStorage;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.math.BlockPos;
@@ -24,8 +24,8 @@ public class IC2EnergyStorageCard extends ItemBaseCard {
         CardState state = CardState.NO_TARGET;
         if (card.hasTagCompound()) {
             BlockPos pos = NBTUtils.getBlockPos(card.getTagCompound());
-            if (world.getTileEntity(pos) instanceof TileEntityElectricBlock) {
-                TileEntityElectricBlock energySource = (TileEntityElectricBlock) world.getTileEntity(pos);
+            if (world.getTileEntity(pos) instanceof IEnergyStorage) {
+                IEnergyStorage energySource = (IEnergyStorage) world.getTileEntity(pos);
                 card.getTagCompound().setInteger("max_storage", energySource.getCapacity());
                 card.getTagCompound().setInteger("capacity", energySource.getStored());
                 card.getTagCompound().setInteger("output", energySource.getOutput());

--- a/src/main/java/worldcontrolteam/worldcontrol/crossmod/industrialcraft2/items/IC2EnergyStorageKit.java
+++ b/src/main/java/worldcontrolteam/worldcontrol/crossmod/industrialcraft2/items/IC2EnergyStorageKit.java
@@ -1,6 +1,6 @@
 package worldcontrolteam.worldcontrol.crossmod.industrialcraft2.items;
 
-import ic2.core.block.wiring.TileEntityElectricBlock;
+import ic2.api.tile.IEnergyStorage;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.BlockPos;
@@ -21,6 +21,6 @@ public class IC2EnergyStorageKit extends ItemBaseKit {
 
     @Override
     public boolean canReturnCard(ItemStack stack, World world, BlockPos pos) {
-        return world.getTileEntity(pos) instanceof TileEntityElectricBlock;
+        return world.getTileEntity(pos) instanceof IEnergyStorage;
     }
 }


### PR DESCRIPTION
that is all I did when it comes to ic2 classic compat. I am not doing anything else in terms of that.
I did clean up he logic in Reactor utils as it was written in a very messy way and made it harder to read.
also I updated the forge version